### PR TITLE
Retry on timeouts. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2018.01.17
+### Changed
+- Timeouts when calling the underlying service should be retried. 
+
 ## [0.3.0] - 2018.12.18
 ### Added
 - Added support for debugFunction and errorFunction options. Defaults to console.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-tagliatelle",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cimpress-tagliatelle",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "A thin client for Cimpress Tagliatelle service",
   "main": "lib/index.js",
   "scripts": {

--- a/src/Tagliatelle.js
+++ b/src/Tagliatelle.js
@@ -61,6 +61,7 @@ class Tagliatelle {
                 retryDelay: (retryCount) => {
                     return this.retryDelayInMs;
                 },
+                shouldResetTimeout: true,
             });
         }
 


### PR DESCRIPTION
From: https://github.com/softonic/axios-retry#Options

> `shouldResetTimeout` -> Defines if the timeout should be reset between retries

So the way I understand it (and to the extent I observed this in logs), if the first request because of timeout, it is likely not going to have time to perform retires unless this is set, right?

